### PR TITLE
ffic: Chart name and add displayName annotation

### DIFF
--- a/charts/unique-ingress-policy/Chart.yaml
+++ b/charts/unique-ingress-policy/Chart.yaml
@@ -2,6 +2,7 @@ annotations:
   kubewarden/contextAwareResources: |
     - apiVersion: networking.k8s.io/v1
       kind: Ingress
+  kubewarden/displayName: Unique Ingress host
   kubewarden/mutation: "false"
   kubewarden/registry: ghcr.io
   kubewarden/repository: kubewarden/policies/unique-ingress-policy
@@ -23,7 +24,7 @@ home: https://github.com/kubewarden/unique-ingress-policy
 keywords:
 - ingress
 - kubewarden
-name: Unique Ingress host
+name: ingress-unique-host
 sources:
 - ghcr.io/kubewarden/policies/unique-ingress-policy:v0.1.5
 version: 0.1.5

--- a/charts/verify-image-signatures/Chart.yaml
+++ b/charts/verify-image-signatures/Chart.yaml
@@ -1,4 +1,5 @@
 annotations:
+  kubewarden/displayName: Verify Image Signatures
   kubewarden/mutation: "true"
   kubewarden/registry: ghcr.io
   kubewarden/repository: kubewarden/policies/verify-image-signatures
@@ -54,7 +55,7 @@ keywords:
 - signature
 - sigstore
 - trusted
-name: Verify Image Signatures
+name: verify-image-signatures
 sources:
 - ghcr.io/kubewarden/policies/verify-image-signatures:v0.3.0
 version: 0.3.0

--- a/pkg2chart/main.go
+++ b/pkg2chart/main.go
@@ -14,6 +14,7 @@ import (
 
 // ArtifactHubPkg represents the structure of an artifacthub-pkg.yml file
 type ArtifactHubPkg struct {
+	Name             string            `yaml:"name"`
 	DisplayName      string            `yaml:"displayName"`
 	Version          string            `yaml:"version"`
 	Description      string            `yaml:"description"`
@@ -63,8 +64,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	ociUrl := pkg.ContainersImages[0].Image
-	ref, err := name.NewTag(ociUrl)
+	ociURL := pkg.ContainersImages[0].Image
+	ref, err := name.NewTag(ociURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing container image URL: %v\n", err)
 		os.Exit(1)
@@ -74,8 +75,10 @@ func main() {
 	annotations["kubewarden/repository"] = ref.Context().RepositoryStr()
 	annotations["kubewarden/tag"] = ref.TagStr()
 
+	annotations["kubewarden/displayName"] = pkg.DisplayName
+
 	metadata := chart.Metadata{
-		Name:        pkg.DisplayName,
+		Name:        pkg.Name,
 		Version:     pkg.Version,
 		AppVersion:  pkg.Version,
 		Description: pkg.Description,


### PR DESCRIPTION
## Description

This PR updates the `name` field in `Chart.yaml` to match the `name` field in `artifacthub-pkg.yml`, which was previously `displayName`. Without this change, the release job would fail when attempting to create a tag based on the display name, which contains invalid characters. Additionally, it adds the display name as an annotation.
